### PR TITLE
Include bnPrimeChainMultiplier in getBlock

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -56,6 +56,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex)
     CBigNum bnPrimeChainOrigin = CBigNum(block.GetHeaderHash()) * block.bnPrimeChainMultiplier;
     result.push_back(Pair("primechain", GetPrimeChainName(blockindex->nPrimeChainType, blockindex->nPrimeChainLength).c_str()));
     result.push_back(Pair("primeorigin", bnPrimeChainOrigin.ToString().c_str()));
+    result.push_back(Pair("primechainmultiplier", block.bnPrimeChainMultiplier.ToString().c_str()));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));


### PR DESCRIPTION
Modify rpcblockchain.cpp to include bnPrimeChainMultiplier in blockToJSON

primecoind getblock <hash> will now return 'primechainmultiplier' 

for example; 

```
root@xpm-testnet2:~/primecoin/src# ./primecoind getblock faba12d46bef122f04929195b29cd0d1cc1ecc0b66d6b35967f3f9c4d8c28fe3
{
    "hash" : "faba12d46bef122f04929195b29cd0d1cc1ecc0b66d6b35967f3f9c4d8c28fe3",
    "confirmations" : 86391,
    "size" : 191,
    "height" : 1,
    "version" : 2,
    "headerhash" : "d4734a23e1e84f0fbd97431e3632cdcc1e23803b4610c9bb6e6fe83c52cda5b6",
    "merkleroot" : "ec89e34f446bab9d7bbe0c14bea9a01a45c9eafbd383c3c7bfdc3e3c91433d81",
    "tx" : [
        "ec89e34f446bab9d7bbe0c14bea9a01a45c9eafbd383c3c7bfdc3e3c91433d81"
    ],
    "time" : 1373071487,
    "nonce" : 141,
    "bits" : "05000000",
    "difficulty" : 5.00000000,
    "transition" : 5.01194412,
    "primechain" : "TWN05.0aa8c4",
    "primeorigin" : "93150759177986512564382881566142700055499531185298653359355631158870499133543215410",
    "primechainmultiplier" : "969371",
    "previousblockhash" : "221156cf301bc3585e72de34fe1efdb6fbd703bc27cfc468faa1cdd889d0efa0",
    "nextblockhash" : "643a8e4b4615c82b91508bcbdd5f8894188fe410a30bc48a624331ed50632f56"
}
```
To allow electrumx to create the hash